### PR TITLE
change value of hdate.Tamuz to Tammuz

### DIFF
--- a/hdate.go
+++ b/hdate.go
@@ -45,7 +45,7 @@ const (
 	Iyyar
 	// Sivan / סיון
 	Sivan
-	// Tamuz (sometimes Tammuz) / תמוז
+	// Tammuz (sometimes Tamuz) / תמוז
 	Tamuz
 	// Av / אב
 	Av
@@ -72,7 +72,7 @@ var longMonthNames = []string{
 	"Nisan",
 	"Iyyar",
 	"Sivan",
-	"Tamuz",
+	"Tammuz",
 	"Av",
 	"Elul",
 	"Tishrei",


### PR DESCRIPTION
In my expeirience, this spelling is more common
Better reflects the original langauge, in which the mem is geminated Brings consistancy with hebcal-go, where the Fast of Tummuz has 2 M's Tammuz is now spelled the same, wether it a fast, rosh chodes, or just any other day Brings consistancy with Iyyar, which already reflects the geminated yud Brings greater consistancy to overall spelling conventions used