### PR TITLE
Fix go 1.17 build: use atomic.LoadInt32/StoreInt32 instead of atomic.Int32

### DIFF
--- a/hdate.go
+++ b/hdate.go
@@ -184,18 +184,18 @@ const (
 	edCacheMax = 6999
 )
 
-var edCache [edCacheMax - edCacheMin + 1]atomic.Int32
+var edCache [edCacheMax - edCacheMin + 1]int32
 
 // elapsedDays returns the number of days from the sunday prior to the start
 // of the Hebrew calendar to the mean conjunction of Tishrei in Hebrew year.
 func elapsedDays(year int) int64 {
 	if year >= edCacheMin && year <= edCacheMax {
 		idx := year - edCacheMin
-		if n := edCache[idx].Load(); n != 0 {
+		if n := atomic.LoadInt32(&edCache[idx]); n != 0 {
 			return int64(n)
 		}
 		v := elapsedDays0(year)
-		edCache[idx].Store(int32(v))
+		atomic.StoreInt32(&edCache[idx], int32(v))
 		return v
 	}
 	return elapsedDays0(year)


### PR DESCRIPTION
## Summary

PR #5 merged with the Go 1.19+ form of atomic (`atomic.Int32` with `.Load()`/`.Store()` methods), but `go.mod` declares `go 1.17` and CI builds against Go 1.17. The current `main` build is failing with:

```
./hdate.go:187:42: undefined: atomic.Int32
```

This switches to the function-form atomics (`atomic.LoadInt32` / `atomic.StoreInt32`) on a plain `[N]int32` array. These have existed since Go 1.0 and generate the same MOV instructions on x86/arm as the typed wrapper, so the cache stays race-free with no change to runtime behavior or performance.

## Test plan

- [x] `go build -v ./...` succeeds
- [x] `go test ./...` passes
- [x] `go test -race ./...` clean
- [x] `go vet ./...` clean
- [x] `staticcheck -checks=all ./...` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_011adJhdgVwYK3P6YeCyFLrG)_